### PR TITLE
Bugfix and Test Coverage for rearch Branch

### DIFF
--- a/brukerbridge/conversion/pv58.py
+++ b/brukerbridge/conversion/pv58.py
@@ -379,6 +379,7 @@ def convert_acquisition_to_nifti(xml_path: Path, compress: bool, max_image_size:
             acq_path / f"{acq_path.name}_channel_{channel_idx}.nii{compress_suffix}"
         )
 
+
         if max_image_size > 0:
             write_nifti_streaming_chunked(
                 header, frame_gen, output_path, max_image_size
@@ -475,8 +476,8 @@ def vol_series_frame_gen(
                 frame_path = frame_element.find(f"./File[@channel='{channel}']").attrib["filename"]  # type: ignore
 
                 with Image.open(xml_path.parent / frame_path) as frame_img:
-                    frame_img_arr = np.array(frame_img)
-                    assert frame_img_arr.T.shape == acq_shape[:2]
+                    frame_img_arr = np.array(frame_img).T
+                    assert frame_img_arr.shape == acq_shape[:2]
                     assert frame_img_arr.dtype == np.uint16
 
                     yield frame_img_arr
@@ -508,8 +509,8 @@ def vol_series_frame_gen(
                         # xml pages are one-indexed, pillow uses zero indexing
                         frame_img.seek(frame_page - 1)
 
-                        frame_img_arr = np.array(frame_img)
-                        assert frame_img_arr.T.shape == acq_shape[:2]
+                        frame_img_arr = np.array(frame_img).T
+                        assert frame_img_arr.shape == acq_shape[:2]
                         assert frame_img_arr.dtype == np.uint16
 
                         yield frame_img_arr
@@ -547,8 +548,8 @@ def plane_series_frame_gen(
             frame_path = frame_element.find(f"./File[@channel='{channel}']").attrib["filename"]  # type: ignore
 
             with Image.open(xml_path.parent / frame_path) as frame_img:
-                frame_img_arr = np.array(frame_img)
-                assert frame_img_arr.T.shape == acq_shape[:2]
+                frame_img_arr = np.array(frame_img).T
+                assert frame_img_arr.shape == acq_shape[:2]
                 assert frame_img_arr.dtype == np.uint16
 
                 yield frame_img_arr
@@ -570,8 +571,8 @@ def plane_series_frame_gen(
                     # xml pages are one-indexed, pillow uses zero indexing
                     frame_img.seek(frame_page - 1)
 
-                    frame_img_arr = np.array(frame_img)
-                    assert frame_img_arr.T.shape == acq_shape[:2]
+                    frame_img_arr = np.array(frame_img).T
+                    assert frame_img_arr.shape == acq_shape[:2]
                     assert frame_img_arr.dtype == np.uint16
 
                     yield frame_img_arr

--- a/brukerbridge/legacy/tiff_to_nii.py
+++ b/brukerbridge/legacy/tiff_to_nii.py
@@ -151,12 +151,9 @@ def tiff_to_nii(xml_file: str, gzip: bool = False):
         save_name = xml_file[:-4] + "_channel_{}".format(channel + 1) + ".nii"
         if gzip:
             save_name += ".gz"
-        if isVolumeSeries:
-            img = nib.nifti1.Nifti1Image(
-                image_array, aff
-            )  # 32 bit: maxes out at 32767 in any one dimension
-        else:
-            img = nib.nifti2.Nifti2Image(image_array, aff)  # 64 bit
+        # NOTE Yilin 2026/01/07: Previously Nifti1 is adopted for volume series.
+        # Now unifying all to Nifti2.
+        img = nib.nifti2.Nifti2Image(image_array, aff)  # 64 bit
         image_array = None  # for memory
         logger.debug("%s, saving nii as %s", xml_file, save_name)
         img.to_filename(save_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -569,6 +569,10 @@ def single_plane_ripped_test_acq_xml_path(request, tmp_path):
 def single_image_ripped_test_acq_xml_path(request, tmp_path):
     return set_up_ripped(tmp_path, request.param)
 
+@pytest.fixture(params=get_matching_ripped_test_acqs("PV5-8", is_complete=True, is_vol=True, is_bidir_z_stroke=False))
+def completed_volume_singledir_ripped_test_acq_xml_path(request, tmp_path):
+    return set_up_ripped(tmp_path, request.param)
+
 
 #  =============================================
 #  ====== fixtures for streaming io tests ======

--- a/tests/test_pv58_conversion_logic.py
+++ b/tests/test_pv58_conversion_logic.py
@@ -1,7 +1,11 @@
 """ Test for XML parsing and associated conversion logic specific to PraireView 5.8
 """
 import nibabel as nib
+import os
+import shutil
 import pytest
+import subprocess
+import warnings
 
 from brukerbridge.constants import AcquisitionType, TiffPageFormat
 from brukerbridge.conversion.pv58 import (
@@ -10,6 +14,7 @@ from brukerbridge.conversion.pv58 import (
     parse_acquisition_resolution, parse_acquisition_shape,
     parse_acquisition_tiff_page_format,
     parse_acquisition_tiff_page_format_fallback, parse_acquisition_type)
+from brukerbridge.legacy import convert_tiff_collections_to_nii
 
 
 def test_parse_acquisition_type_detects_volume_series(volume_test_acq_xml_path):
@@ -177,6 +182,35 @@ def test_create_acquisition_nifti_header(pv58_test_acq_xml_path):
 
 # extremely slow
 @pytest.mark.slow
+def test_convert_completed_volume_singledir_no_compress_no_chunk(
+    tmp_path, completed_volume_singledir_ripped_test_acq_xml_path
+):
+    tmp_rearch_path = tmp_path / "test_acq" / "rearch"
+    tmp_legacy_path = tmp_path / "test_acq" / "legacy"
+    os.makedirs(tmp_rearch_path)
+    os.makedirs(tmp_legacy_path)
+
+    convert_acquisition_to_nifti(
+        completed_volume_singledir_ripped_test_acq_xml_path, False, -1
+    )
+    output_files = list((tmp_path / "test_acq").glob("*.nii"))
+    for f in output_files:
+        new_name = f.name.split("_channel_", 1)[1]
+        shutil.move(f, tmp_rearch_path / new_name)
+
+    warnings.simplefilter(action='ignore', category=FutureWarning)
+    convert_tiff_collections_to_nii(str(completed_volume_singledir_ripped_test_acq_xml_path.parent), False)
+    warnings.simplefilter(action='default', category=FutureWarning)
+    output_files = list((tmp_path / "test_acq").glob("*.nii"))
+    for f in output_files:
+        new_name = f.name.split("_channel_", 1)[1]
+        shutil.move(f, tmp_legacy_path / new_name)
+
+    result = subprocess.run(["diff", "-r", str(tmp_rearch_path), str(tmp_legacy_path)], capture_output=True, text=True, check=True)
+    assert result.returncode == 0
+
+# extremely slow
+@pytest.mark.slow
 def test_convert_ripped_2ch_no_compress_no_chunk(
     tmp_path, two_channel_singledir_ripped_test_acq_xml_path
 ):
@@ -190,7 +224,6 @@ def test_convert_ripped_2ch_no_compress_no_chunk(
     output_files = list((tmp_path / "test_acq").glob("*.nii"))
 
     assert len(output_files) == 2
-
 
 # extremely slow
 @pytest.mark.slow


### PR DESCRIPTION
Fixed a bug that the output is unexpectedly transposed. Enhanced test coverage by comparing rearch and legacy conversion results.